### PR TITLE
chore: remove links about state of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,3 @@ Currently in alpha. It'll be moved to beta as soon as we have every layout tool 
 a list of every feature we need to release a stable version of Beagle Flutter and its status.
 
 It's important to reiterate that Beagle is an open source project and every help is welcomed!
-
-### Major features
-
-todo: check https://docs.google.com/spreadsheets/d/1aSo7eZsj2lEnTG0kKzta-U4G9qkgA8v1w9kpyrPlVPA/edit?usp=sharing
-
-### Default components
-
-todo: check https://docs.google.com/spreadsheets/d/1aSo7eZsj2lEnTG0kKzta-U4G9qkgA8v1w9kpyrPlVPA/edit?usp=sharing
-
-### Default actions
-
-todo: check https://docs.google.com/spreadsheets/d/1aSo7eZsj2lEnTG0kKzta-U4G9qkgA8v1w9kpyrPlVPA/edit?usp=sharing


### PR DESCRIPTION
### Description and Example

These links don't update anymore and the people outside the project can't be accessed, because this doesn't make sense to share.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
