### PR TITLE
feat: Fixes deprecated warnings by upgrading flutter to 2.5.1

### DIFF
--- a/.github/workflows/flutter-pr.yml
+++ b/.github/workflows/flutter-pr.yml
@@ -19,6 +19,7 @@ jobs:
             -   uses: subosito/flutter-action@v1
                 with:
                   channel: 'stable' # or: 'dev' or 'beta'
+                  flutter-version: '2.5.1'
             # Gems for Fastlane
             -   name: Cache ruby gems dependencies
                 uses: actions/cache@v2


### PR DESCRIPTION
### Related Issues
Fixes the following issue:

This app is using a deprecated version of the Android embedding.
To avoid unexpected runtime failures, or future build failures, try to migrate this app to the V2 embedding.
Take a look at the docs for migrating an app: https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects
The plugin `beagle` requires your app to be migrated to the Android embedding v2. Follow the steps on https://flutter.dev/go/android-project-migration and re-run this command.

### Description and Example

To run this version you must use the command to upgrade the flutter engine:

```
flutter upgrade
flutter channel stable
flutter doctor -v
[✓] Flutter (Channel stable, 2.5.1, on macOS 12.2.1 21D62 darwin-x64, locale pt-BR)
    • Flutter version 2.5.1 at /Users/${user}/development/flutter
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision ffb2ecea52 (6 months ago), 2021-09-17 15:26:33 -0400
    • Engine revision b3af521a05
    • Dart version 2.14.2
```
### Checklist	

Please, check if these important points are met using `[x]`:	

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.	
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->	
- [x] I am willing to follow-up on review comments in a timely manner.	
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:	

<!-- Links -->	
[PR Guide]: https://github.com/ZupIT/beagle/blob/main/doc/contributing/pull_requests.md
